### PR TITLE
ci: deactivate unused workflows

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,14 +1,16 @@
 ---
 name: "CLA Assistant"
 on:  # yamllint disable-line rule:truthy
-  issue_comment:
-    types:
-      - created
-  pull_request_target:
-    types:
-      - opened
-      - closed
-      - synchronize
+  # TOPOS: deactivated for now, replaced with workflow_dispatch
+  # issue_comment:
+  #   types:
+  #     - created
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - closed
+  #     - synchronize
+  workflow_dispatch:
 
 jobs:
   CLAssistant:

--- a/.github/workflows/deploy.devnet.eph.yml
+++ b/.github/workflows/deploy.devnet.eph.yml
@@ -2,10 +2,11 @@
 name: Ephemeral DevNet Workflow
 
 on:  # yamllint disable-line rule:truthy
+  # TOPOS: deactivated for now, replaced with workflow_dispatch
   workflow_dispatch:
-  push:
-    branches:
-      - develop
+  # push:
+  #   branches:
+  #     - develop
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.devnet.yml
+++ b/.github/workflows/deploy.devnet.yml
@@ -2,10 +2,11 @@
 name: DevNet Workflow
 
 on:  # yamllint disable-line rule:truthy
+  # TOPOS: deactivated for now, replaced with workflow_dispatch
   workflow_dispatch:
-  push:
-    branches:
-      - develop
+  # push:
+  #   branches:
+  #     - develop
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy.testnet.yml
+++ b/.github/workflows/deploy.testnet.yml
@@ -1,10 +1,11 @@
 ---
 name: TestNet Workflow
 on:  # yamllint disable-line rule:truthy
+  # TOPOS: deactivated for now, replaced with workflow_dispatch
   workflow_dispatch:
-  push:
-    branches:
-      - 'release/**'
+  # push:
+  #   branches:
+  #     - 'release/**'
 
 permissions:
   id-token: write

--- a/.github/workflows/deploy_edgenet.yaml
+++ b/.github/workflows/deploy_edgenet.yaml
@@ -1,8 +1,10 @@
 ---
 on:  # yamllint disable-line rule:truthy
-  release:
-    types:
-      - published
+  # TOPOS: deactivated for now, replaced with workflow_dispatch
+  # release:
+  #   types:
+  #     - published
+  workflow_dispatch:
 
 jobs:
   deploy_to_edge_net:


### PR DESCRIPTION
# Description

Deactivate unused workflows for now (deploy workflows) by using `workflow_dispatch` as the sole workflow trigger.
