### PR TITLE
fix: always generate even compressed public keys

### DIFF
--- a/secrets/helper/helper.go
+++ b/secrets/helper/helper.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"math/big"
@@ -77,9 +78,25 @@ func InitECDSAValidatorKey(secretsManager secrets.SecretsManager) (types.Address
 		return types.ZeroAddress, fmt.Errorf(`secrets "%s" has been already initialized`, secrets.ValidatorKey)
 	}
 
-	validatorKey, validatorKeyEncoded, err := crypto.GenerateAndEncodeECDSAPrivateKey()
-	if err != nil {
-		return types.ZeroAddress, err
+	// As a temporary workaround until sequencer switches to FROST signatures,
+	// it expects even secp256k1 public keys (when compressed starting with 0x02)
+	// Generate private keys until you get even public key
+	var (
+		validatorKey        *ecdsa.PrivateKey
+		validatorKeyEncoded []byte
+		err                 error
+	)
+
+	for {
+		validatorKey, validatorKeyEncoded, err = crypto.GenerateAndEncodeECDSAPrivateKey()
+		if err != nil {
+			return types.ZeroAddress, err
+		}
+
+		y := validatorKey.PublicKey.Y.Bytes()
+		if y[31]%2 == 0 {
+			break
+		}
 	}
 
 	address := crypto.PubKeyToAddress(&validatorKey.PublicKey)


### PR DESCRIPTION
# Description

Workaround for sequencer requirement that subnet id is last 32 of compressed even public key.

Fixes TP-514

## Additions and Changes

Generate validator private key in the loop  until public key gets even.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
