### PR TITLE
fix: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # Docker
 
-/docker/local @topos-network/protocol @topos-network/tools
+/docker @topos-network/protocol @topos-network/tools


### PR DESCRIPTION
# Description

`CODEOWNERS` attributes `docker/local` to Tools & Protocol teams, but we're having our updates in `docker/local-topos`. This PR replaces the former with the broader `docker` path.

## Additions and Changes

- Update `CODEOWNERS` to replace `docker/local` with `docker`

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
