### PR TITLE
chore: quiet fail if contract already predeployed

### DIFF
--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -41,7 +41,6 @@ case "$1" in
                     BOOTNODE_ADDRESS=$(echo $secrets | jq -r '.[0] | .address')
 
                     echo "Generating IBFT Genesis file..."
-                    ls -la "$POLYGON_EDGE_BIN"
                     "$POLYGON_EDGE_BIN" genesis $CHAIN_CUSTOM_OPTIONS \
                       --dir "$GENESIS_PATH" \
                       --consensus ibft \
@@ -80,12 +79,12 @@ case "$1" in
 
         echo "Predeploying ConstAddressDeployer contract..."
         CONST_ADDRESS_DEPLOYER_ADDRESS=0x0000000000000000000000000000000000001110
-        ls -la "$POLYGON_EDGE_BIN"
         "$POLYGON_EDGE_BIN" genesis predeploy \
-        --chain "$GENESIS_PATH" \
-        --artifacts-path "$CONTRACTS_PATH"/ConstAddressDeployer.json \
-        --predeploy-address "$CONST_ADDRESS_DEPLOYER_ADDRESS"
-        echo "ConstAddressDeployer has been successfully predeployed!"
+          --chain "$GENESIS_PATH" \
+          --artifacts-path "$CONTRACTS_PATH"/ConstAddressDeployer.json \
+          --predeploy-address "$CONST_ADDRESS_DEPLOYER_ADDRESS" \
+          2>&1 >/dev/null && echo "ConstAddressDeployer has been successfully predeployed!" \
+          || echo "Predeployment of ConstAddressDeployer failed with error code $?"
     ;;
 
     *)


### PR DESCRIPTION
# Description

The docker `polygon-edge.sh` init script deploys the `ConstAddressDeployer` contract. Re-running the init script/container fails as the contract already exists on-chain.

This PR makes the pre-deploy command quietly fails (but still output the error message).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
