### PR TITLE
feat: run standalone node test

### DIFF
--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -87,6 +87,25 @@ case "$1" in
           || echo "Predeployment of ConstAddressDeployer failed with error code $?"
     ;;
 
+    "standalone-test")
+        echo "Cleaning up previous execution..."
+        rm -rf genesis.json data-1
+        echo "Generating node secrets..."
+        NODE_ID=`$POLYGON_EDGE_BIN secrets init --insecure --num 1 --data-dir data-1 | grep Node | awk '{ print $4}'`
+        echo "Boot node id: " $NODE_ID
+        echo "Validator private key:" `cat data-1/consensus/validator.key`
+        echo "Generating genesis script..."
+        "$POLYGON_EDGE_BIN" genesis --dir genesis.json \
+         --consensus ibft \
+         --ibft-validators-prefix-path data- \
+         --validator-set-size=1 \
+         --premine=0x4AAb25B4fAd0Beaac466050f3A7142A502f4Cf0a:1000000000000000000000 \
+         --bootnode /ip4/127.0.0.1/tcp/10001/p2p/$NODE_ID
+
+        echo "Executing polygon-edge standalone node..."
+        exec "$POLYGON_EDGE_BIN" server --data-dir ./data-1 --chain genesis.json
+    ;;    
+
     *)
         echo "Executing polygon-edge..."
         exec "$POLYGON_EDGE_BIN" "$@"


### PR DESCRIPTION
# Description

Provide simple option for `polygon-edge.sh` to execute standalone node with default parameters

Fixes TP-527

## Additions and Changes

`standalone-test` `polygon-edge.sh` command will generate secrets, generate genesis file and run one node from scratch for every execution. Account with premined tokens is `0x4AAb25B4fAd0Beaac466050f3A7142A502f4Cf0a`. Usage will be primary for `sequencer` integration tests.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
