### PR TITLE
fix: revert docker stack to IBFT and fix a few commands

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        # with:
-        #   submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -40,9 +38,6 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      # - name: Compile contracts
-      #   run: cd core-contracts && npm install && npm run compile
       
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
+        # with:
+        #   submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -41,8 +41,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Compile contracts
-        run: cd core-contracts && npm install && npm run compile
+      # - name: Compile contracts
+      #   run: cd core-contracts && npm install && npm run compile
       
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3

--- a/docker/local-topos/Dockerfile
+++ b/docker/local-topos/Dockerfile
@@ -9,8 +9,6 @@ RUN go mod download
 
 COPY . .
 
-RUN go run ./consensus/polybft/contractsapi/artifacts-gen/main.go
-
 RUN go build -o polygon-edge main.go
 
 FROM alpine:latest AS runner
@@ -21,7 +19,6 @@ WORKDIR /polygon-edge
 
 COPY --from=builder /polygon-edge/polygon-edge ./
 COPY ./docker/local-topos/polygon-edge.sh ./
-COPY ./core-contracts/artifacts ./core-contracts/artifacts
 
 # Expose json-rpc, libp2p and grpc ports
 EXPOSE 8545 9632 1478 5001

--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -42,13 +42,14 @@ case "$1" in
                     BOOTNODE_ADDRESS=$(echo $secrets | jq -r '.[0] | .address')
 
                     echo "Generating IBFT Genesis file..."
-                    "$POLYGON_EDGE_BIN" genesis $CHAIN_CUSTOM_OPTIONS \
-                      --dir "$GENESIS_PATH" \
+                    cd /data && /polygon-edge/polygon-edge genesis $CHAIN_CUSTOM_OPTIONS \
+                      --dir genesis.json \
                       --consensus ibft \
                       --ibft-validators-prefix-path data- \
                       --validator-set-size=$NUMBER_OF_NODES \
                       --bootnode /dns4/"$BOOTNODE_DOMAIN_NAME"/tcp/1478/p2p/$BOOTNODE_ID \
-                      --premine=$BOOTNODE_ADDRESS:1000000000000000000000
+                      --premine=$BOOTNODE_ADDRESS:1000000000000000000000 \
+                    && cd /polygon-edge
                 fi    
             ;;
 

--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -34,7 +34,8 @@ case "$1" in
                     echo "Secrets have already been generated."
                 else
                     echo "Generating secrets..."
-                    secrets=$("$POLYGON_EDGE_BIN" secrets init --insecure --num "$NUMBER_OF_NODES" --data-dir "$data_dir" --json)
+                    secrets=$("$POLYGON_EDGE_BIN" secrets init --insecure \
+                    --num "$NUMBER_OF_NODES" --data-dir "$data_dir" --json)
                     echo "Secrets have been successfully generated"
 
                     BOOTNODE_ID=$(echo $secrets | jq -r '.[0] | .node_id')
@@ -56,7 +57,8 @@ case "$1" in
                     echo "Secrets have already been generated."
                 else
                     echo "Generating PolyBFT secrets..."
-                    secrets=$("$POLYGON_EDGE_BIN" polybft-secrets init --insecure --num "$NUMBER_OF_NODES" --data-dir "$data_dir" --json)
+                    secrets=$("$POLYGON_EDGE_BIN" polybft-secrets init --insecure \
+                    --num "$NUMBER_OF_NODES" --data-dir "$data_dir" --json)
                     chmod -R 755 /data # TOPOS: To make secret readable from the sequencer
                     echo "Secrets have been successfully generated"
 
@@ -64,7 +66,8 @@ case "$1" in
                     BOOTNODE_ADDRESS=$(echo $secrets | jq -r '.[0] | .address')
 
                     echo "Generating manifest..."
-                    "$POLYGON_EDGE_BIN" manifest --path /data/manifest.json --validators-path /data --validators-prefix data-
+                    "$POLYGON_EDGE_BIN" manifest --path /data/manifest.json --validators-path /data \
+                    --validators-prefix data- --chain-id "$CHAIN_ID"
 
                     echo "Generating PolyBFT Genesis file..."
                     "$POLYGON_EDGE_BIN" genesis $CHAIN_CUSTOM_OPTIONS \

--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -36,6 +36,7 @@ case "$1" in
                     echo "Generating secrets..."
                     secrets=$("$POLYGON_EDGE_BIN" secrets init --insecure \
                     --num "$NUMBER_OF_NODES" --data-dir "$data_dir" --json)
+                    chmod -R 755 /data # TOPOS: To make secret readable from the sequencer
                     echo "Secrets have been successfully generated"
 
                     BOOTNODE_ID=$(echo $secrets | jq -r '.[0] | .node_id')


### PR DESCRIPTION
# Description

Fix a few things w.r.t. the `docker/local-topos` stack.

## Additions and Changes

### Bug fix (non-breaking change which fixes an issue)

- Add missing `--chain-id` flag in `PolyBFT` manifest file generation
- Reset Dockerfile to work with `ibft` instead of `polybft` (still waiting for Polygon documentation to fully grasp what `polybft` revolves around—seems to be for `supernets` only)
- Change recursively `/data` folder's permissions to allow for read and unit tests later
- Re-use `cd /data` strategy for `ibft` genesis file generation (from `docker/local`)

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
