### PR TITLE
chore: adapt ConstAddressDeployer path to hardhat dir structure

### DIFF
--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -86,7 +86,7 @@ case "$1" in
         CONST_ADDRESS_DEPLOYER_ADDRESS=0x0000000000000000000000000000000000001110
         "$POLYGON_EDGE_BIN" genesis predeploy \
           --chain "$GENESIS_PATH" \
-          --artifacts-path "$CONTRACTS_PATH"/ConstAddressDeployer.json \
+          --artifacts-path "$CONTRACTS_PATH"/topos-core/ConstAddressDeployer.sol/ConstAddressDeployer.json \
           --predeploy-address "$CONST_ADDRESS_DEPLOYER_ADDRESS" \
           2>&1 >/dev/null && echo "ConstAddressDeployer has been successfully predeployed!" \
           || echo "Predeployment of ConstAddressDeployer failed with error code $?"


### PR DESCRIPTION
# Description

[PR-57](https://github.com/toposware/topos-smart-contracts/pull/57) from `topos-smart-contracts` introduces a new file directory structure for contracts. This PR updates the docker script to take that change into account.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
