### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
 ---
 name: Release
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   push:
     branches-ignore:
-      - '**'
+      - "**"
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
       # to be used by fork patch-releases ^^
-      - 'v*.*.*-*'
+      - "v*.*.*-*"
 
 jobs:
   goreleaser:
@@ -38,8 +38,6 @@ jobs:
           		--privileged \
           		-e CGO_ENABLED=1 \
           		-e GITHUB_TOKEN \
-          		-e DOCKER_USERNAME \
-          		-e DOCKER_PASSWORD \
           		-e SLACK_WEBHOOK \
           		-v /var/run/docker.sock:/var/run/docker.sock \
           		-v `pwd`:/go/src/$(PACKAGE_NAME) \
@@ -47,11 +45,9 @@ jobs:
           		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
           		--rm-dist --skip-validate
         env:
-          PACKAGE_NAME: github.com/0xPolygon/polygon-edge
+          PACKAGE_NAME: github.com/topos-network/polygon-edge
           GOLANG_CROSS_VERSION: v1.18.3
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.prepare.outputs.tag_name }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,8 +16,7 @@ builds:
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-    ldflags:
-      -s -w -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+    ldflags: -s -w -X 'github.com/topos-network/polygon-edge/versioning.Version=v{{ .Version }}'
 
   - id: darwin-arm64
     main: ./main.go
@@ -29,8 +28,7 @@ builds:
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-    ldflags:
-      -s -w -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+    ldflags: -s -w -X 'github.com/topos-network/polygon-edge/versioning.Version=v{{ .Version }}'
 
   - id: linux-amd64
     main: ./main.go
@@ -44,7 +42,7 @@ builds:
       - CXX=g++
     ldflags:
       # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+      -s -w -linkmode external -extldflags "-static" -X 'github.com/topos-network/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
       - osusergo
@@ -61,14 +59,13 @@ builds:
       - CXX=aarch64-linux-gnu-g++
     ldflags:
       # We need to build a static binary because we are building in a glibc based system and running in a musl container
-      -s -w -linkmode external -extldflags "-static" -X 'github.com/0xPolygon/polygon-edge/versioning.Version=v{{ .Version }}'
+      -s -w -linkmode external -extldflags "-static" -X 'github.com/topos-network/polygon-edge/versioning.Version=v{{ .Version }}'
     tags:
       - netgo
       - osusergo
 
 archives:
-  -
-    files:
+  - files:
       - LICENSE
       - README.md
 
@@ -96,39 +93,3 @@ archives:
 
 snapshot:
   name_template: "{{ .Tag }}.next"
-
-dockers:
-  - image_templates:
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-    dockerfile: Dockerfile.release
-    use: buildx
-    goarch: amd64
-    ids:
-      - linux-amd64
-    build_flag_templates:
-      - --platform=linux/amd64
-    skip_push: false
-
-  - image_templates:
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
-    dockerfile: Dockerfile.release
-    use: buildx
-    goarch: arm64
-    ids:
-      - linux-arm64
-    build_flag_templates:
-      - --platform=linux/arm64
-    skip_push: false
-
-docker_manifests:
-  - name_template: 0xpolygon/{{ .ProjectName }}:{{ .Version }}
-    image_templates:
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
-    skip_push: false
-
-  - name_template: 0xpolygon/{{ .ProjectName }}:latest
-    image_templates:
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-amd64
-      - 0xpolygon/{{ .ProjectName }}:{{ .Version }}-arm64
-    skip_push: auto


### PR DESCRIPTION
# Description

The `release` CI workflow is currently broken because of hardcoded links referring to the upstream project. This PR fixes this by updating the workflow and the `goreleaser` config file.

An example of a release can be found with the **to-be-deleted** [v0.9.0 draft version](https://github.com/topos-network/polygon-edge/releases/tag/untagged-1b93de72a08e1cd79493).

Fixes TOO-288

## Additions and Changes

- Update `release` workflow with `topos-network` links
- Update `.goreleaser.yml` config file to remove Docker jobs (not needed now) and update links to `topos-network`
- Configure our own Slack webhook and channel secrets along with a custom PolygonEdge Slack app (not fully tested yet)

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
