### PR TITLE
fix: jsonrpc get storage and tracer

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/umbracle/fastrlp"
 
 	"github.com/0xPolygon/polygon-edge/chain"
 	"github.com/0xPolygon/polygon-edge/helper/common"
@@ -358,23 +357,8 @@ func (e *Eth) GetStorageAt(
 		return nil, err
 	}
 
-	// TODO: GetStorage should return the values already parsed
-
-	// Parse the RLP value
-	p := &fastrlp.Parser{}
-
-	v, err := p.Parse(result)
-	if err != nil {
-		return argBytesPtr(types.ZeroHash[:]), nil
-	}
-
-	data, err := v.Bytes()
-	if err != nil {
-		return argBytesPtr(types.ZeroHash[:]), nil
-	}
-
 	// Pad to return 32 bytes data
-	return argBytesPtr(types.BytesToHash(data).Bytes()), nil
+	return argBytesPtr(types.BytesToHash(result).Bytes()), nil
 }
 
 // GasPrice returns the average gas price based on the last x blocks


### PR DESCRIPTION
# Description

Fixes couple of issues with Polygon Edge jsonrpc api and tracer
* return correct result from `eth_getStorageAt`
* write correct values in storage traces
* save tracer state with `CALL` operation to generate correct trace for `CALL`/`STATICCALL` operations


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
