### PR TITLE
feat: add get prover data api function

### DIFF
--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -135,7 +135,7 @@ func (d *Debug) TraceTransaction(
 		return nil, ErrTraceGenesisBlock
 	}
 
-	tracer, cancel, err := newTracer(config)
+	tracer, cancel, err := NewTracer(config)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (d *Debug) TraceCall(
 		tx.Gas = header.GasLimit
 	}
 
-	tracer, cancel, err := newTracer(config)
+	tracer, cancel, err := NewTracer(config)
 	defer cancel()
 
 	if err != nil {
@@ -183,7 +183,7 @@ func (d *Debug) traceBlock(
 		return nil, ErrTraceGenesisBlock
 	}
 
-	tracer, cancel, err := newTracer(config)
+	tracer, cancel, err := NewTracer(config)
 	defer cancel()
 
 	if err != nil {
@@ -193,8 +193,8 @@ func (d *Debug) traceBlock(
 	return d.store.TraceBlock(block, tracer)
 }
 
-// newTracer creates new tracer by config
-func newTracer(config *TraceConfig) (
+// NewTracer creates new tracer by config
+func NewTracer(config *TraceConfig) (
 	tracer.Tracer,
 	context.CancelFunc,
 	error,

--- a/jsonrpc/debug_endpoint_test.go
+++ b/jsonrpc/debug_endpoint_test.go
@@ -688,13 +688,13 @@ func TestTraceCall(t *testing.T) {
 	}
 }
 
-func Test_newTracer(t *testing.T) {
+func Test_NewTracer(t *testing.T) {
 	t.Parallel()
 
 	t.Run("should create tracer", func(t *testing.T) {
 		t.Parallel()
 
-		tracer, cancel, err := newTracer(&TraceConfig{
+		tracer, cancel, err := NewTracer(&TraceConfig{
 			EnableMemory:     true,
 			EnableReturnData: true,
 			DisableStack:     false,
@@ -712,7 +712,7 @@ func Test_newTracer(t *testing.T) {
 	t.Run("should return error if arg is nil", func(t *testing.T) {
 		t.Parallel()
 
-		tracer, cancel, err := newTracer(nil)
+		tracer, cancel, err := NewTracer(nil)
 
 		assert.Nil(t, tracer)
 		assert.Nil(t, cancel)
@@ -723,7 +723,7 @@ func Test_newTracer(t *testing.T) {
 		t.Parallel()
 
 		timeout := "0s"
-		tracer, cancel, err := newTracer(&TraceConfig{
+		tracer, cancel, err := NewTracer(&TraceConfig{
 			EnableMemory:     true,
 			EnableReturnData: true,
 			DisableStack:     false,
@@ -749,7 +749,7 @@ func Test_newTracer(t *testing.T) {
 		t.Parallel()
 
 		timeout := "5s"
-		tracer, cancel, err := newTracer(&TraceConfig{
+		tracer, cancel, err := NewTracer(&TraceConfig{
 			EnableMemory:     true,
 			EnableReturnData: true,
 			DisableStack:     false,

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -39,9 +39,9 @@ type Account struct {
 
 type ethStateStore interface {
 	GetAccount(root types.Hash, addr types.Address) (*Account, error)
+	GetAccountProof(root types.Hash, addr types.Address) ([][]byte, error)
 	GetStorage(root types.Hash, addr types.Address, slot types.Hash) ([]byte, error)
-	// Return contract storage root node hash encoded in RLP and keccak256 hash of it
-	GetContractStorageData(stateRoot types.Hash, addr types.Address) ([]byte, types.Hash, error)
+	GetStorageProof(stateRoot types.Hash, addr types.Address, slot types.Hash) ([][]byte, error)
 	GetForksInTime(blockNumber uint64) chain.ForksInTime
 	GetCode(root types.Hash, addr types.Address) ([]byte, error)
 }
@@ -798,18 +798,32 @@ func (e *Eth) GetProverData(block BlockNumberOrHash) (interface{}, error) {
 
 	for account, accountData := range accounts {
 		if accountData.CodeHash != EmptyCodeHash {
+			storageUpdates := make([]prover.StorageUpdate, 0)
+
 			// Account has code
-			rlpRootData, storageHash, err := e.store.GetContractStorageData(header.StateRoot,
-				types.StringToAddress(account))
-			if err != nil {
-				return nil, err
+			for _, storageChange := range storageChanges[account] {
+				storageMerkleProof, err := e.store.GetStorageProof(header.StateRoot,
+					types.StringToAddress(account), storageChange.Slot)
+				if err != nil {
+					return nil, err
+				}
+
+				ss := make([]string, len(storageMerkleProof))
+				for i, s := range storageMerkleProof {
+					ss[i] = hex.EncodeToHex(s)
+				}
+
+				storageUpdates = append(storageUpdates, prover.StorageUpdate{
+					Value:       storageChange.Value.String(),
+					Slot:        storageChange.Slot.String(),
+					MerkleProof: ss,
+				})
 			}
 
 			storages = append(storages, prover.Storage{
 				Account:     account,
-				Hash:        storageHash,
-				RootRlpHash: rlpRootData,
-				Storage:     storageChanges[account],
+				StorageRoot: accountData.Root,
+				Storage:     storageUpdates,
 			})
 		}
 	}
@@ -838,6 +852,26 @@ func (e *Eth) GetProverData(block BlockNumberOrHash) (interface{}, error) {
 		}
 	}
 
+	state := make([]prover.ProverAccountProof, 0)
+
+	// Get state Merkle proofs for all accounts
+	for account := range accounts {
+		accountProof, err := e.store.GetAccountProof(header.StateRoot, types.StringToAddress(account))
+		if err != nil {
+			return nil, err
+		}
+
+		aa := make([]string, 0)
+		for _, proof := range accountProof {
+			aa = append(aa, hex.EncodeToHex(proof))
+		}
+
+		state = append(state, prover.ProverAccountProof{
+			Account:     account,
+			MerkleProof: aa,
+		})
+	}
+
 	return &prover.ProverData{
 		BlockHeader:   *header,
 		Accounts:      accounts,
@@ -845,5 +879,6 @@ func (e *Eth) GetProverData(block BlockNumberOrHash) (interface{}, error) {
 		Transactions:  transactions,
 		Receipts:      receipts,
 		ContractCodes: contractCodes,
+		State:         state,
 	}, nil
 }

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -1,3 +1,4 @@
+// Package prover contains structures and utility functions for the prover
 package prover
 
 import (
@@ -7,9 +8,17 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
+type Storage struct {
+	Account     string
+	Hash        types.Hash
+	RootRlpHash []byte
+	Storage     []structtracer.StorageUpdate
+}
+
 type ProverData struct {
 	BlockHeader types.Header
 	Accounts    interface{}
+	Storage     interface{}
 }
 
 func ParseBlockAccounts(block *types.Block) ([]string, error) {
@@ -44,4 +53,21 @@ func ParseContractCodeForAccounts(tracesJSON []interface{}) ([]string, error) {
 	}
 
 	return result, nil
+}
+
+func ParseTraceForStorageChanges(tracesJSON []interface{}) (map[string][]structtracer.StorageUpdate, error) {
+	var storageChanges = make(map[string][]structtracer.StorageUpdate)
+
+	for _, traceJSON := range tracesJSON {
+		trace, ok := traceJSON.(*structtracer.StructTraceResult)
+		if !ok {
+			return nil, fmt.Errorf("invalid struct trace data conversion")
+		}
+
+		for account, storage := range trace.StorageUpdates {
+			storageChanges[account.String()] = append(storageChanges[account.String()], storage...)
+		}
+	}
+
+	return storageChanges, nil
 }

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -3,6 +3,7 @@ package prover
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/0xPolygon/polygon-edge/state/runtime/tracer/structtracer"
 	"github.com/0xPolygon/polygon-edge/types"
@@ -15,10 +16,20 @@ type Storage struct {
 	Storage     []structtracer.StorageUpdate
 }
 
+type ProverAccount struct {
+	Balance  *big.Int
+	Nonce    uint64
+	Root     string
+	CodeHash string
+}
+
 type ProverData struct {
-	BlockHeader types.Header
-	Accounts    interface{}
-	Storage     interface{}
+	BlockHeader   types.Header
+	Accounts      interface{}
+	Storage       interface{}
+	Transactions  interface{}
+	Receipts      interface{}
+	ContractCodes interface{}
 }
 
 func ParseBlockAccounts(block *types.Block) ([]string, error) {

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -1,0 +1,47 @@
+package prover
+
+import (
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/state/runtime/tracer/structtracer"
+	"github.com/0xPolygon/polygon-edge/types"
+)
+
+type ProverData struct {
+	BlockHeader types.Header
+	Accounts    interface{}
+}
+
+func ParseBlockAccounts(block *types.Block) ([]string, error) {
+	var accounts = make([]string, 0)
+	for _, tx := range block.Transactions {
+		accounts = append(accounts, tx.From.String())
+		accounts = append(accounts, (*tx.To).String())
+	}
+
+	return accounts, nil
+}
+
+func ParseContractCodeForAccounts(tracesJSON []interface{}) ([]string, error) {
+	var accounts = make(map[string]int)
+
+	for _, traceJSON := range tracesJSON {
+		trace, ok := traceJSON.(*structtracer.StructTraceResult)
+		if !ok {
+			return nil, fmt.Errorf("invalid struct trace data conversion")
+		}
+
+		for _, log := range trace.StructLogs {
+			if log.Op == "CALL" || log.Op == "STATICCALL" {
+				accounts[log.Stack[len(log.Stack)-2]] = 1
+			}
+		}
+	}
+
+	result := make([]string, 0)
+	for account := range accounts {
+		result = append(result, account)
+	}
+
+	return result, nil
+}

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -9,11 +9,16 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
+type StorageUpdate struct {
+	Slot        string
+	Value       string
+	MerkleProof []string
+}
+
 type Storage struct {
 	Account     string
-	Hash        types.Hash
-	RootRlpHash []byte
-	Storage     []structtracer.StorageUpdate
+	StorageRoot string
+	Storage     []StorageUpdate
 }
 
 type ProverAccount struct {
@@ -23,6 +28,11 @@ type ProverAccount struct {
 	CodeHash string
 }
 
+type ProverAccountProof struct {
+	Account     string
+	MerkleProof []string
+}
+
 type ProverData struct {
 	BlockHeader   types.Header
 	Accounts      interface{}
@@ -30,6 +40,7 @@ type ProverData struct {
 	Transactions  interface{}
 	Receipts      interface{}
 	ContractCodes interface{}
+	State         interface{}
 }
 
 func ParseBlockAccounts(block *types.Block) ([]string, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -608,6 +608,7 @@ func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*jsonrpc.A
 	return account, nil
 }
 
+// TODO: use eth_getProof once it is available in Polygon Edge
 func (j *jsonRPCHub) GetAccountProof(root types.Hash, addr types.Address) ([][]byte, error) {
 	proof, err := getAccountProofImpl(j.state, root, addr)
 	if err != nil {
@@ -638,6 +639,7 @@ func (j *jsonRPCHub) GetStorage(stateRoot types.Hash, addr types.Address, slot t
 	return res.Bytes(), nil
 }
 
+// TODO: use eth_getProof once it is available in Polygon Edge
 func (j *jsonRPCHub) GetStorageProof(stateRoot types.Hash, addr types.Address, slot types.Hash) ([][]byte, error) {
 	account, err := getAccountImpl(j.state, stateRoot, addr)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -584,8 +584,10 @@ func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*jsonrpc.A
 	}
 
 	account := &jsonrpc.Account{
-		Nonce:   acct.Nonce,
-		Balance: new(big.Int).Set(acct.Balance),
+		Nonce:    acct.Nonce,
+		Balance:  new(big.Int).Set(acct.Balance),
+		Root:     acct.Root,
+		CodeHash: acct.CodeHash,
 	}
 
 	return account, nil

--- a/server/server.go
+++ b/server/server.go
@@ -614,6 +614,25 @@ func (j *jsonRPCHub) GetStorage(stateRoot types.Hash, addr types.Address, slot t
 	return res.Bytes(), nil
 }
 
+func (j *jsonRPCHub) GetContractStorageData(stateRoot types.Hash, addr types.Address) ([]byte, types.Hash, error) {
+	account, err := getAccountImpl(j.state, stateRoot, addr)
+	if err != nil {
+		return nil, types.Hash{}, err
+	}
+
+	snap, err := j.state.NewSnapshotAt(stateRoot)
+	if err != nil {
+		return nil, types.Hash{}, err
+	}
+
+	rlpRootHash, keccakRootHash, err := snap.GetContractStorageData(addr, account.Root)
+	if err != nil {
+		return nil, types.Hash{}, err
+	}
+
+	return rlpRootHash, keccakRootHash, nil
+}
+
 func (j *jsonRPCHub) GetCode(root types.Hash, addr types.Address) ([]byte, error) {
 	account, err := getAccountImpl(j.state, root, addr)
 	if err != nil {

--- a/state/immutable-trie/hasher.go
+++ b/state/immutable-trie/hasher.go
@@ -1,6 +1,7 @@
 package itrie
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"hash"
@@ -196,6 +197,10 @@ func (t *Txn) hash(node Node, h *hasher, a *fastrlp.Arena, d int) *fastrlp.Value
 	// Write data
 	if t.batch != nil {
 		t.batch.Put(tmp, h.buf)
+	}
+
+	if t.rootHashes != nil {
+		t.rootHashes[hex.EncodeToString(hh)] = h.buf
 	}
 
 	return a.NewCopyBytes(hh)

--- a/state/immutable-trie/hasher.go
+++ b/state/immutable-trie/hasher.go
@@ -205,3 +205,72 @@ func (t *Txn) hash(node Node, h *hasher, a *fastrlp.Arena, d int) *fastrlp.Value
 
 	return a.NewCopyBytes(hh)
 }
+
+// Returns (hash, rlp) value
+func (t *Txn) rlp(node Node, h *hasher, a *fastrlp.Arena, d int) (*fastrlp.Value, *fastrlp.Value) {
+	var hash *fastrlp.Value
+
+	var aa *fastrlp.Arena
+
+	var idx int
+
+	if hash, rlp, ok := node.Rlp(); ok {
+		return a.NewCopyBytes(hash), a.NewCopyBytes(rlp)
+	}
+
+	switch n := node.(type) {
+	case *ValueNode:
+		return a.NewCopyBytes(n.buf), a.NewCopyBytes(n.buf)
+
+	case *ShortNode:
+		childHash := t.hash(n.child, h, a, d+1)
+
+		hash = a.NewArray()
+		hash.Set(a.NewBytes(encodeCompact(n.key)))
+		hash.Set(childHash)
+
+	case *FullNode:
+		hash = a.NewArray()
+
+		aa, idx = h.AcquireArena()
+
+		for _, i := range n.children {
+			if i == nil {
+				hash.Set(a.NewNull())
+			} else {
+				hash.Set(t.hash(i, h, aa, d+1))
+			}
+		}
+
+		// Add the value
+		if n.value == nil {
+			hash.Set(a.NewNull())
+		} else {
+			hash.Set(t.hash(n.value, h, a, d+1))
+		}
+
+	default:
+		panic(fmt.Sprintf("unknown node type %v", n)) //nolint:gocritic
+	}
+
+	if hash.Len() < 32 {
+		return hash, hash
+	}
+
+	// marshal RLP value
+	h.buf = hash.MarshalTo(h.buf[:0])
+
+	if aa != nil {
+		h.ReleaseArenas(idx)
+	}
+
+	tmp := h.Hash(h.buf)
+	hh, rr := node.SetRlp(tmp, h.buf)
+
+	// Write data
+	if t.batch != nil {
+		t.batch.Put(tmp, h.buf)
+	}
+
+	return a.NewCopyBytes(hh), a.NewCopyBytes(rr)
+}

--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -2,6 +2,7 @@ package itrie
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -51,6 +52,29 @@ func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.
 	}
 
 	return types.BytesToHash(res)
+}
+
+func (s *Snapshot) GetContractStorageData(addr types.Address, root types.Hash) ([]byte, types.Hash, error) {
+	var (
+		err  error
+		trie *Trie
+	)
+
+	if root == emptyStateHash {
+		trie = s.state.newTrie()
+	} else {
+		trie, err = s.state.newTrieAt(root)
+		if err != nil {
+			return nil, types.Hash{}, err
+		}
+	}
+
+	rlpRootHash, keccakRootHash, ok := trie.GetRootRlpData(s.state.storage)
+	if !ok {
+		return nil, types.Hash{}, errors.New("unable to get storage data")
+	}
+
+	return rlpRootHash, keccakRootHash, nil
 }
 
 func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {

--- a/state/immutable-trie/snapshot.go
+++ b/state/immutable-trie/snapshot.go
@@ -2,7 +2,6 @@ package itrie
 
 import (
 	"bytes"
-	"errors"
 
 	"github.com/0xPolygon/polygon-edge/crypto"
 	"github.com/0xPolygon/polygon-edge/state"
@@ -54,7 +53,7 @@ func (s *Snapshot) GetStorage(addr types.Address, root types.Hash, rawkey types.
 	return types.BytesToHash(res)
 }
 
-func (s *Snapshot) GetContractStorageData(addr types.Address, root types.Hash) ([]byte, types.Hash, error) {
+func (s *Snapshot) GetStorageProof(addr types.Address, root types.Hash, slot types.Hash) ([][]byte, error) {
 	var (
 		err  error
 		trie *Trie
@@ -65,16 +64,23 @@ func (s *Snapshot) GetContractStorageData(addr types.Address, root types.Hash) (
 	} else {
 		trie, err = s.state.newTrieAt(root)
 		if err != nil {
-			return nil, types.Hash{}, err
+			return nil, err
 		}
 	}
 
-	rlpRootHash, keccakRootHash, ok := trie.GetRootRlpData(s.state.storage)
+	key := crypto.Keccak256(slot.Bytes())
+
+	proof, ok := trie.GetProof(key, s.state.storage)
 	if !ok {
-		return nil, types.Hash{}, errors.New("unable to get storage data")
+		return nil, nil
 	}
 
-	return rlpRootHash, keccakRootHash, nil
+	// Reverse merkle proof array, so that root is at the beginning
+	for i, j := 0, len(proof)-1; i < j; i, j = i+1, j-1 {
+		proof[i], proof[j] = proof[j], proof[i]
+	}
+
+	return proof, nil
 }
 
 func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {
@@ -91,6 +97,22 @@ func (s *Snapshot) GetAccount(addr types.Address) (*state.Account, error) {
 	}
 
 	return &account, nil
+}
+
+func (s *Snapshot) GetAccountProof(addr types.Address) ([][]byte, error) {
+	key := crypto.Keccak256(addr.Bytes())
+
+	proof, ok := s.trie.GetProof(key, s.state.storage)
+	if !ok {
+		return nil, nil
+	}
+
+	// Reverse merkle proof array, so that root is at the beginning
+	for i, j := 0, len(proof)-1; i < j; i, j = i+1, j-1 {
+		proof[i], proof[j] = proof[j], proof[i]
+	}
+
+	return proof, nil
 }
 
 func (s *Snapshot) GetCode(hash types.Hash) ([]byte, bool) {

--- a/state/immutable-trie/trie.go
+++ b/state/immutable-trie/trie.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	commonHelpers "github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/0xPolygon/polygon-edge/helper/hex"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -106,6 +107,20 @@ func (t *Trie) Get(k []byte, storage Storage) ([]byte, bool) {
 	return res, res != nil
 }
 
+func (t *Trie) GetRootRlpData(storage Storage) ([]byte, types.Hash, bool) {
+	txn := t.Txn(storage)
+
+	// While calculating root keccak hash, rlp hash of the root node is also calculated
+	keccakHash, err := txn.Hash()
+	if err != nil {
+		return nil, types.Hash{}, false
+	}
+
+	rlpHash := txn.rootHashes[hex.EncodeToString(keccakHash[:])]
+
+	return rlpHash, types.BytesToHash(keccakHash), len(rlpHash) != 0
+}
+
 func hashit(k []byte) []byte {
 	h := sha3.NewLegacyKeccak256()
 	h.Write(k)
@@ -136,7 +151,8 @@ func (t *Trie) hashRoot() []byte {
 }
 
 func (t *Trie) Txn(storage Storage) *Txn {
-	return &Txn{root: t.root, epoch: t.epoch + 1, storage: storage}
+	return &Txn{root: t.root, epoch: t.epoch + 1, storage: storage,
+		rootHashes: make(map[string][]byte)}
 }
 
 type Putter interface {
@@ -148,6 +164,8 @@ type Txn struct {
 	epoch   uint32
 	storage Storage
 	batch   Putter
+	// Map of root keccak hash to its full rlp root hash
+	rootHashes map[string][]byte
 }
 
 func (t *Txn) Commit() *Trie {
@@ -213,6 +231,88 @@ func (t *Txn) lookup(node interface{}, key []byte) (Node, []byte) {
 		}
 
 		return nil, res
+
+	default:
+		panic(fmt.Sprintf("unknown node type %v", n)) //nolint:gocritic
+	}
+}
+
+func decodeRlp(value []byte) types.Hash {
+	p := &fastrlp.Parser{}
+
+	v, err := p.Parse(value)
+	if err != nil {
+		return types.Hash{}
+	}
+
+	res := []byte{}
+	if res, err = v.GetBytes(res[:0]); err != nil {
+		return types.Hash{}
+	}
+
+	return types.BytesToHash(res)
+}
+
+func (t *Txn) PrintTrie() {
+	t.printTrie(t.root, 0)
+
+	return
+}
+
+func (t *Txn) printTrie(node interface{}, level int) {
+	for i := 0; i <= level; i++ {
+		fmt.Print(" ")
+	}
+
+	switch n := node.(type) {
+	case nil:
+		return
+
+	case *ValueNode:
+		if n.hash {
+			nc, ok, err := GetNode(n.buf, t.storage)
+			if err != nil {
+				panic(err) //nolint:gocritic
+			}
+
+			if !ok {
+				return
+			}
+
+			t.printTrie(nc, level+1)
+
+			return
+		} else {
+			fmt.Println("ValueNode level", level, " value:", decodeRlp(n.buf))
+		}
+
+		return
+
+	case *ShortNode:
+		fmt.Println("ShortNode level", level, " common:", hex.EncodeToHex(n.common.hash),
+			" key:", hex.EncodeToHex(n.key))
+
+		t.printTrie(n.child, level+1)
+
+		return
+
+	case *FullNode:
+		fmt.Println("FullNode level", level, " number of children:", len(n.children),
+			" common:", hex.EncodeToHex(n.common.hash), " value:", n.value)
+
+		if n.value != nil {
+			t.printTrie(n.value, level+1)
+		}
+
+		for i, child := range n.children {
+			if child != nil {
+				fmt.Println("FullNode level", level, " entering child:", i)
+			}
+
+			t.printTrie(child, level+1)
+		}
+
+		return
 
 	default:
 		panic(fmt.Sprintf("unknown node type %v", n)) //nolint:gocritic

--- a/state/runtime/tracer/structtracer/tracer_test.go
+++ b/state/runtime/tracer/structtracer/tracer_test.go
@@ -191,9 +191,11 @@ func TestStructTracerTxStart(t *testing.T) {
 			storage: []map[types.Address]map[types.Hash]types.Hash{
 				make(map[types.Address]map[types.Hash]types.Hash),
 			},
-			gasLimit:      gasLimit,
-			currentMemory: make([]([]byte), 1),
-			currentStack:  make([]([]*big.Int), 1),
+			gasLimit:              gasLimit,
+			currentMemory:         make([]([]byte), 1),
+			currentStack:          make([]([]*big.Int), 1),
+			storageUpdates:        make([][]StorageUpdate, 1),
+			accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 		},
 		tracer,
 	)
@@ -219,10 +221,12 @@ func TestStructTracerTxEnd(t *testing.T) {
 			storage: []map[types.Address]map[types.Hash]types.Hash{
 				make(map[types.Address]map[types.Hash]types.Hash),
 			},
-			gasLimit:      gasLimit,
-			consumedGas:   gasLimit - gasLeft,
-			currentMemory: make([]([]byte), 1),
-			currentStack:  make([]([]*big.Int), 1),
+			gasLimit:              gasLimit,
+			consumedGas:           gasLimit - gasLeft,
+			currentMemory:         make([]([]byte), 1),
+			currentStack:          make([]([]*big.Int), 1),
+			storageUpdates:        make([][]StorageUpdate, 1),
+			accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 		},
 		tracer,
 	)
@@ -276,10 +280,12 @@ func TestStructTracerCallEnd(t *testing.T) {
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
 				},
-				output:        output,
-				err:           err,
-				currentMemory: make([]([]byte), 1),
-				currentStack:  make([]([]*big.Int), 1),
+				output:                output,
+				err:                   err,
+				currentMemory:         make([]([]byte), 1),
+				currentStack:          make([]([]*big.Int), 1),
+				storageUpdates:        make([][]StorageUpdate, 1),
+				accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 			},
 		},
 		{
@@ -292,8 +298,10 @@ func TestStructTracerCallEnd(t *testing.T) {
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
 				},
-				currentMemory: make([]([]byte), 1),
-				currentStack:  make([]([]*big.Int), 1),
+				currentMemory:         make([]([]byte), 1),
+				currentStack:          make([]([]*big.Int), 1),
+				storageUpdates:        make([][]StorageUpdate, 1),
+				accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 			},
 		},
 	}
@@ -448,6 +456,8 @@ func TestStructTracerCaptureState(t *testing.T) {
 				storage: []map[types.Address]map[types.Hash]types.Hash{
 					make(map[types.Address]map[types.Hash]types.Hash),
 				},
+				storageUpdates:        make([][]StorageUpdate, 1),
+				accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 			},
 			memory:          memory,
 			stack:           stack,
@@ -468,7 +478,14 @@ func TestStructTracerCaptureState(t *testing.T) {
 							types.BytesToHash(big.NewInt(2).Bytes()): types.BytesToHash(big.NewInt(1).Bytes()),
 						},
 					},
-				}},
+				},
+				storageUpdates: [][]StorageUpdate{
+					{
+						StorageUpdate{types.BytesToHash(big.NewInt(2).Bytes()), types.BytesToHash(big.NewInt(1).Bytes())},
+					},
+				},
+				accountStorageUpdates: make(map[types.Address][]StorageUpdate),
+			},
 			expectedVMState: &mockState{},
 		},
 		{
@@ -915,15 +932,21 @@ func TestStructTracerGetResult(t *testing.T) {
 		{
 			name: "should return result",
 			tracer: &StructTracer{
-				Config:      testEmptyConfig,
-				logs:        logs,
-				consumedGas: consumedGas,
-				output:      returnData,
+				Config:                testEmptyConfig,
+				logs:                  logs,
+				consumedGas:           consumedGas,
+				output:                returnData,
+				storageUpdates:        make([][]StorageUpdate, 1),
+				accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 			},
 			expected: &StructTraceResult{
+				Account:     "0x0000000000000000000000000000000000000000",
 				Failed:      false,
 				Gas:         consumedGas,
 				ReturnValue: hex.EncodeToString(returnData),
+				StorageUpdates: map[types.Address][]StorageUpdate{
+					{}: nil,
+				},
 				StructLogs: []StructLogRes{
 					{
 						Pc:            ip,
@@ -957,16 +980,22 @@ func TestStructTracerGetResult(t *testing.T) {
 		{
 			name: "should return empty ReturnValue if error is marked",
 			tracer: &StructTracer{
-				Config:      testEmptyConfig,
-				logs:        logs,
-				consumedGas: consumedGas,
-				output:      returnData,
-				err:         err,
+				Config:                testEmptyConfig,
+				logs:                  logs,
+				consumedGas:           consumedGas,
+				output:                returnData,
+				err:                   err,
+				storageUpdates:        make([][]StorageUpdate, 1),
+				accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 			},
 			expected: &StructTraceResult{
 				Failed:      true,
 				Gas:         consumedGas,
 				ReturnValue: "",
+				Account:     "0x0000000000000000000000000000000000000000",
+				StorageUpdates: map[types.Address][]StorageUpdate{
+					{}: nil,
+				},
 				StructLogs: []StructLogRes{
 					{
 						Pc:            ip,
@@ -1000,9 +1029,11 @@ func TestStructTracerGetResult(t *testing.T) {
 		{
 			name: "should return error",
 			tracer: &StructTracer{
-				Config: testEmptyConfig,
-				reason: reason,
-				logs:   logs,
+				Config:                testEmptyConfig,
+				reason:                reason,
+				logs:                  logs,
+				storageUpdates:        make([][]StorageUpdate, 1),
+				accountStorageUpdates: make(map[types.Address][]StorageUpdate),
 			},
 			expected: nil,
 			err:      reason,

--- a/state/txn.go
+++ b/state/txn.go
@@ -16,9 +16,9 @@ var emptyStateHash = types.StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e
 
 type readSnapshot interface {
 	GetStorage(addr types.Address, root types.Hash, key types.Hash) types.Hash
-	// Return rlp root hash of the smart contract storage and keccak256 of that hash
-	GetContractStorageData(addr types.Address, root types.Hash) ([]byte, types.Hash, error)
+	GetStorageProof(addr types.Address, root types.Hash, key types.Hash) ([][]byte, error)
 	GetAccount(addr types.Address) (*Account, error)
+	GetAccountProof(addr types.Address) ([][]byte, error)
 	GetCode(hash types.Hash) ([]byte, bool)
 }
 

--- a/state/txn.go
+++ b/state/txn.go
@@ -16,6 +16,8 @@ var emptyStateHash = types.StringToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e
 
 type readSnapshot interface {
 	GetStorage(addr types.Address, root types.Hash, key types.Hash) types.Hash
+	// Return rlp root hash of the smart contract storage and keccak256 of that hash
+	GetContractStorageData(addr types.Address, root types.Hash) ([]byte, types.Hash, error)
 	GetAccount(addr types.Address) (*Account, error)
 	GetCode(hash types.Hash) ([]byte, bool)
 }

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -45,6 +45,10 @@ func (m *mockSnapshot) GetCode(hash types.Hash) ([]byte, bool) {
 	return nil, false
 }
 
+func (m *mockSnapshot) GetContractStorageData(addr types.Address, root types.Hash) ([]byte, types.Hash, error) {
+	return nil, types.Hash{}, nil
+}
+
 func newStateWithPreState(preState map[types.Address]*PreState) readSnapshot {
 	return &mockSnapshot{state: preState}
 }

--- a/state/txn_test.go
+++ b/state/txn_test.go
@@ -41,12 +41,16 @@ func (m *mockSnapshot) GetAccount(addr types.Address) (*Account, error) {
 	return acct, nil
 }
 
+func (m *mockSnapshot) GetAccountProof(addr types.Address) ([][]byte, error) {
+	return nil, nil
+}
+
 func (m *mockSnapshot) GetCode(hash types.Hash) ([]byte, bool) {
 	return nil, false
 }
 
-func (m *mockSnapshot) GetContractStorageData(addr types.Address, root types.Hash) ([]byte, types.Hash, error) {
-	return nil, types.Hash{}, nil
+func (m *mockSnapshot) GetStorageProof(addr types.Address, root types.Hash, slot types.Hash) ([][]byte, error) {
+	return nil, nil
 }
 
 func newStateWithPreState(preState map[types.Address]*PreState) readSnapshot {


### PR DESCRIPTION
# Description

Implement jsonrpc `eth_getProverData` api function that returns account data used in the block.

Fixes TP-612

## Additions and Changes
* JSONRPC interface expanded with `eth_getProverData` function
* Added prover module for implementation of data retrieval and filtering functions
* Internal APIs are updated to run the tracer, retrieve merkle proof for the contract storage and state

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
