### PR TITLE
ci: push multi-platform docker images

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -38,12 +38,13 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      
+
       - name: Push to GitHub Container Registry
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           file: ./docker/local-topos/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Description

Docker images are only built with the default `linux/amd64` platform. This PR adds the `linux/arm64` platform to add support for arm based architectures (e.g., Apple Silicon macs).

## Additions and Changes

### New feature (non-breaking change which adds functionality)
- Specify explicitly platforms to be used as target in the docker-build-push community Github Action

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
