### PR TITLE
feat: update prover storage data

### DIFF
--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -906,13 +906,13 @@ func (e *Eth) GetProverData(block BlockNumberOrHash) (interface{}, error) {
 		})
 	}
 
-	chainId, err := e.ChainId()
+	chainID, err := e.ChainId()
 	if err != nil {
 		return nil, err
 	}
 
 	return &prover.ProverData{
-		ChainId:             chainId,
+		ChainID:             chainID,
 		BlockHeader:         *header,
 		PreviousBlockHeader: *previousHeader,
 		Accounts:            accounts,

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -798,7 +798,7 @@ func (e *Eth) GetProverData(block BlockNumberOrHash) (interface{}, error) {
 		}
 	}
 
-	// Lear of the storage changes in this block
+	// Learn of the storage changes in this block
 	storages := make([]prover.Storage, 0)
 
 	storageChanges, err := prover.ParseTraceForStorageAccess(tracesJSON)

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -9,7 +9,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
-type StorageUpdate struct {
+type StorageAccess struct {
 	Slot        string
 	MerkleProof []string
 }
@@ -17,7 +17,7 @@ type StorageUpdate struct {
 type Storage struct {
 	Account     string
 	StorageRoot string
-	Storage     []StorageUpdate
+	Storage     []StorageAccess
 }
 
 type ProverAccount struct {
@@ -78,8 +78,8 @@ func ParseContractCodeForAccounts(tracesJSON []interface{}) ([]string, error) {
 	return result, nil
 }
 
-func ParseTraceForStorageChanges(tracesJSON []interface{}) (map[string][]structtracer.StorageUpdate, error) {
-	var storageChanges = make(map[string][]structtracer.StorageUpdate)
+func ParseTraceForStorageAccess(tracesJSON []interface{}) (map[string][]structtracer.StorageAccess, error) {
+	var storageChanges = make(map[string][]structtracer.StorageAccess)
 
 	for _, traceJSON := range tracesJSON {
 		trace, ok := traceJSON.(*structtracer.StructTraceResult)
@@ -88,7 +88,9 @@ func ParseTraceForStorageChanges(tracesJSON []interface{}) (map[string][]structt
 		}
 
 		for account, storage := range trace.StorageUpdates {
-			storageChanges[account.String()] = append(storageChanges[account.String()], storage...)
+			for storageAccess := range storage {
+				storageChanges[account.String()] = append(storageChanges[account.String()], storageAccess)
+			}
 		}
 	}
 

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -11,7 +11,6 @@ import (
 
 type StorageUpdate struct {
 	Slot        string
-	Value       string
 	MerkleProof []string
 }
 
@@ -34,13 +33,15 @@ type ProverAccountProof struct {
 }
 
 type ProverData struct {
-	BlockHeader   types.Header
-	Accounts      interface{}
-	Storage       interface{}
-	Transactions  interface{}
-	Receipts      interface{}
-	ContractCodes interface{}
-	State         interface{}
+	ChainId             interface{}
+	BlockHeader         types.Header
+	PreviousBlockHeader types.Header
+	Accounts            interface{}
+	PreviousStorage     interface{}
+	Transactions        interface{}
+	Receipts            interface{}
+	ContractCodes       interface{}
+	PreviousState       interface{}
 }
 
 func ParseBlockAccounts(block *types.Block) ([]string, error) {

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -33,7 +33,7 @@ type ProverAccountProof struct {
 }
 
 type ProverData struct {
-	ChainId             interface{}
+	ChainID             interface{}
 	BlockHeader         types.Header
 	PreviousBlockHeader types.Header
 	Accounts            interface{}


### PR DESCRIPTION
# Description

State and storage should be from before executing transactions from the block for which proof is generated. Provide also previous block header.

Fixes TP-629

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
