### PR TITLE
ci: deactivate polybft e2e tests workflow

### DIFF
--- a/.github/workflows/e2e-polybft.yml
+++ b/.github/workflows/e2e-polybft.yml
@@ -1,11 +1,11 @@
 ---
 name: PolyBFT E2E tests
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
+  # push:
+  #   branches:
+  #     - main
+  #     - develop
+  # pull_request:
   workflow_dispatch:
   workflow_call:
     outputs:


### PR DESCRIPTION
# Description

This PR deactivates the polybft e2e tests workflow as we do not use it and is currently failing after cutting long build times from our CI budget.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
