### PR TITLE
feat: test network long blocks

### DIFF
--- a/consensus/ibft/signer/helper_test.go
+++ b/consensus/ibft/signer/helper_test.go
@@ -73,7 +73,7 @@ func Test_wrapCommitHash(t *testing.T) {
 	assert.Equal(t, expectedOutput, output)
 }
 
-// nolint
+//nolint
 func Test_getOrCreateECDSAKey(t *testing.T) {
 	t.Parallel()
 
@@ -184,7 +184,7 @@ func Test_getOrCreateECDSAKey(t *testing.T) {
 	}
 }
 
-// nolint
+//nolint
 func Test_getOrCreateBLSKey(t *testing.T) {
 	t.Parallel()
 

--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -7,6 +7,7 @@ CONTRACTS_PATH=/contracts
 GENESIS_PATH=/data/genesis.json
 CHAIN_ID="${CHAIN_ID:-100}" # 100 is Edge's default value
 NUMBER_OF_NODES="${NUMBER_OF_NODES:-4}" # Number of subnet nodes in the consensus
+BLOCK_TIME="${BLOCK_TIME:-2s}" # Block time in seconds
 BOOTNODE_DOMAIN_NAME="${BOOTNODE_DOMAIN_NAME:-node-1}"
 CHAIN_CUSTOM_OPTIONS=$(tr "\n" " " << EOL
 --block-gas-limit 10000000
@@ -46,6 +47,7 @@ case "$1" in
                     cd /data && /polygon-edge/polygon-edge genesis $CHAIN_CUSTOM_OPTIONS \
                       --dir genesis.json \
                       --consensus ibft \
+                      --block-time $BLOCK_TIME \
                       --ibft-validators-prefix-path data- \
                       --max-validator-count=$NUMBER_OF_NODES \
                       --bootnode /dns4/"$BOOTNODE_DOMAIN_NAME"/tcp/1478/p2p/$BOOTNODE_ID \
@@ -75,6 +77,7 @@ case "$1" in
                     "$POLYGON_EDGE_BIN" genesis $CHAIN_CUSTOM_OPTIONS \
                       --dir "$GENESIS_PATH" \
                       --consensus polybft \
+                      --block-time $BLOCK_TIME \
                       --manifest /data/manifest.json \
                       --max-validator-count=$NUMBER_OF_NODES \
                       --bootnode /dns4/"$BOOTNODE_DOMAIN_NAME"/tcp/1478/p2p/$BOOTNODE_ID
@@ -102,6 +105,7 @@ case "$1" in
         echo "Generating genesis script..."
         "$POLYGON_EDGE_BIN" genesis --dir genesis.json \
          --consensus ibft \
+         --block-time $BLOCK_TIME \
          --ibft-validators-prefix-path data- \
          --max-validator-count=1 \
          --premine=0x4AAb25B4fAd0Beaac466050f3A7142A502f4Cf0a:1000000000000000000000 \

--- a/docker/local-topos/polygon-edge.sh
+++ b/docker/local-topos/polygon-edge.sh
@@ -111,7 +111,7 @@ case "$1" in
          --premine=0x4AAb25B4fAd0Beaac466050f3A7142A502f4Cf0a:1000000000000000000000 \
          --bootnode /ip4/127.0.0.1/tcp/10001/p2p/$NODE_ID
 
-        echo "Executing polygon-edge standalone node..."
+        echo "Executing polygon-edge standalone node with block time " $BLOCK_TIME
         exec "$POLYGON_EDGE_BIN" server --data-dir ./data-1 --chain genesis.json
     ;;    
 

--- a/server/server.go
+++ b/server/server.go
@@ -705,7 +705,6 @@ func (j *jsonRPCHub) GetAccount(root types.Hash, addr types.Address) (*jsonrpc.A
 	return account, nil
 }
 
-// TODO: use eth_getProof once it is available in Polygon Edge
 func (j *jsonRPCHub) GetAccountProof(root types.Hash, addr types.Address) ([][]byte, error) {
 	proof, err := getAccountProofImpl(j.state, root, addr)
 	if err != nil {
@@ -736,7 +735,6 @@ func (j *jsonRPCHub) GetStorage(stateRoot types.Hash, addr types.Address, slot t
 	return res.Bytes(), nil
 }
 
-// TODO: use eth_getProof once it is available in Polygon Edge
 func (j *jsonRPCHub) GetStorageProof(stateRoot types.Hash, addr types.Address, slot types.Hash) ([][]byte, error) {
 	account, err := getAccountImpl(j.state, stateRoot, addr)
 	if err != nil {


### PR DESCRIPTION
# Description

Added option for custom block time when starting Polygon Edge, `BLOCK_TIME`. Default is 2 secods.

# Changes include

- [x] New feature (non-breaking change that adds functionality)


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [] I have tested this code with the official test suite
- [x] I have tested this code manually